### PR TITLE
Fix startwith newlines

### DIFF
--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -328,6 +328,38 @@ nestedStartWithStubs =
         parent
 
 
+nestedStartWithRecords : Mark.Document (List ( ( String, String ), List ( String, String ) ))
+nestedStartWithRecords =
+    let
+        parent : Mark.Block (List ( ( String, String ), List ( String, String ) ))
+        parent =
+            Mark.block "Parent"
+                List.singleton
+                (Mark.startWith
+                    Tuple.pair
+                    first
+                    (Mark.manyOf [ second ])
+                )
+
+        first : Mark.Block ( String, String )
+        first =
+            Mark.record2 "First"
+                Tuple.pair
+                (Mark.field "a" Mark.string)
+                (Mark.field "b" Mark.string)
+
+        second : Mark.Block ( String, String )
+        second =
+            Mark.record2 "Second"
+                Tuple.pair
+                (Mark.field "a" Mark.string)
+                (Mark.field "b" Mark.string)
+    in
+    Mark.document
+        identity
+        parent
+
+
 suite : Test
 suite =
     describe "Mark"
@@ -551,6 +583,26 @@ Then some text.
 """)
                         )
                         (Ok [ ( "I'm first", "I'm second" ) ])
+            , test "Nested startWith with records" <|
+                \_ ->
+                    Expect.equal
+                        (Result.mapError (List.map .problem)
+                            (Mark.parse nestedStartWithRecords """| Parent
+    | First
+        a = First a
+        b = First b
+
+    | Second
+        a = Second a
+        b = Second b
+""")
+                        )
+                        (Ok
+                            [ ( ( "First a", "First b" )
+                              , [ ( "Second a", "Second b" ) ]
+                              )
+                            ]
+                        )
             ]
         , describe "Blocks"
             [ test "Misspelled Block" <|

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -302,6 +302,32 @@ sectionWithRecordDoc =
         )
 
 
+nestedStartWithStubs : Mark.Document (List ( String, String ))
+nestedStartWithStubs =
+    let
+        parent : Mark.Block (List ( String, String ))
+        parent =
+            Mark.block "Parent"
+                List.singleton
+                (Mark.startWith
+                    Tuple.pair
+                    first
+                    second
+                )
+
+        first : Mark.Block String
+        first =
+            Mark.stub "First" "I'm first"
+
+        second : Mark.Block String
+        second =
+            Mark.stub "Second" "I'm second"
+    in
+    Mark.document
+        identity
+        parent
+
+
 suite : Test
 suite =
     describe "Mark"
@@ -416,7 +442,7 @@ suite =
     Here is my second.
 
     Here is my third.
-  
+
     Here is my fourth.
 
         And my indented line.
@@ -432,7 +458,7 @@ suite =
     Here is my second.
 
     Here is my third.
-  
+
     Here is my fourth.
 
         And my indented line.
@@ -513,6 +539,18 @@ Then some text.
                             , Indexed 2 []
                             ]
                         )
+            , test "Nested startWith with stubs" <|
+                \_ ->
+                    Expect.equal
+                        (Result.mapError (List.map .problem)
+                            (Mark.parse nestedStartWithStubs """| Parent
+
+    | First
+
+    | Second
+""")
+                        )
+                        (Ok [ ( "I'm first", "I'm second" ) ])
             ]
         , describe "Blocks"
             [ test "Misspelled Block" <|
@@ -667,7 +705,7 @@ Finally, a sentence
     one = hello
 
     two = world
-    
+
     three = !
 """
                     in


### PR DESCRIPTION
As discussed on Slack I have added the test cases for `startWith`. 

In 2.0.5 We found two bugs (#10 and another one that I was in process of reporting while you released the fix, demo here: https://ellie-app.com/4t4fPZcC9Tva1). Both cases are covered by new tests.

I see my editor removed some trailing new lines. I hope that's ok.