### PR TITLE
Fix #40: trim spaces when parsing, not rendering

### DIFF
--- a/src/Mark.elm
+++ b/src/Mark.elm
@@ -1829,7 +1829,7 @@ string =
             \desc ->
                 case desc of
                     DescribeString id range str ->
-                        Outcome.Success (String.trim str)
+                        Outcome.Success str
 
                     _ ->
                         Outcome.Failure NoMatch
@@ -1860,7 +1860,7 @@ string =
                     ParseBlock ->
                         Parser.map
                             (\( pos, str ) ->
-                                DescribeString id pos str
+                                DescribeString id pos (String.trim str)
                             )
                             (Parse.withRange
                                 (Parse.withIndent
@@ -1873,7 +1873,7 @@ string =
                     ParseInTree ->
                         Parser.map
                             (\( pos, str ) ->
-                                DescribeString id pos str
+                                DescribeString id pos (String.trim str)
                             )
                             (Parse.withRange
                                 (Parse.withIndent


### PR DESCRIPTION
Trailing spaces from string blocks were not rendered, even when the block was created using Mark.New.string. See <https://github.com/mdgriffith/elm-markup/issues/40>.

This PR removes the trimming when string is rendered and instead adds trimming to string block parser. That way documents parsed from string behave the same as before, but programmatically inserted whitespace is preserved.