### PR TITLE
Fix: Error when inserting an empty list in manyOf

### DIFF
--- a/src/Mark/Internal/Description.elm
+++ b/src/Mark/Internal/Description.elm
@@ -863,7 +863,7 @@ matchExpected subExp expected =
             List.all (matchExpectedOptions twoOptions) oneOptions
 
         ( ExpectManyOf oneOptions, ExpectManyOf twoOptions ) ->
-            List.all (matchExpectedOptions twoOptions) oneOptions
+            List.all (matchExpectedOptions oneOptions) twoOptions
 
         ( ExpectStartsWith oneStart oneRemain, ExpectStartsWith twoStart twoRemain ) ->
             matchExpected oneStart twoStart


### PR DESCRIPTION
The bug is described in https://github.com/mdgriffith/elm-markup/issues/42, but I would not consider this PR a fix as it does not address the error message helpfullness. Seems like more work need to be done there.

The problem this PR addresses is in the `ExpectManyOf` case of `Mark.Internal.Description.matchExpected`. There are two variables there:

  - `oneOptions` 
  - `twoOptions`

In case of updates `oneOptions` will be a list of all valid options. The `twoOptions` will be a list of blocks that are actually inserted.

We want to check if all inserted blocks match any of the valid options. But it was the other way around - the test was "Are all valid options inserted?". Coincidentally when there is only one valid option and one block is inserted, the result is the same. That's probably why the problem remained undetected for relatively long time. I ran into it becasue my list was nested in a record (as described in the linked issue) and was initially empty.

That's also why I consider the error message unhelpful. It suggested there is something wrong with the record, but the "problem" was nested in one of the fields. I have some thoughts about improving this, but one thing at a time :D